### PR TITLE
Turbo Native -> Hotwire Native

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Turbo Native Directory</title>
+  <title>Hotwire Native Directory</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📱</text></svg>">
   <meta charset="utf-8">
-  <meta name="description" content="Discover a directory of Turbo Native applications. Explore curated listings of web apps built with Turbo and find the latest innovations in mobile development.">
+  <meta name="description" content="Discover a directory of Hotwire Native applications. Explore curated listings of web apps built with Turbo and find the latest innovations in mobile development.">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Rename Turbo Native to Hotwire Native in `<title>` tag and `description` meta tag.